### PR TITLE
refactor: use item sales uom on new orders

### DIFF
--- a/shipstation_integration/items.py
+++ b/shipstation_integration/items.py
@@ -122,4 +122,4 @@ def create_item(
 		print("Error saving Item:\n", e)
 		frappe.log_error(title="Error saving Item", message=e)
 
-	return item.item_code
+	return item

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Union
 import frappe
 from frappe.utils import flt, getdate
 from frappe.utils.safe_exec import is_job_queued
+from erpnext.stock.doctype.item.item import get_uom_conv_factor
 from httpx import HTTPError
 
 from shipstation_integration.customer import (
@@ -182,15 +183,15 @@ def create_erpnext_order(
 			continue
 
 		settings = frappe.get_doc("Shipstation Settings", store.parent)
-		item_code = create_item(item, settings=settings, store=store)
+		stock_item = create_item(item, settings=settings, store=store)
 		item_notes = get_item_notes(item)
 		so.append(
 			"items",
 			{
-				"item_code": item_code,
+				"item_code": stock_item.item_code,
 				"qty": item.quantity,
-				"uom": frappe.db.get_value("Item", item_code, "sales_uom"),
-				"conversion_factor": 1,
+				"uom": stock_item.sales_uom,
+				"conversion_factor": get_uom_conv_factor(stock_item.sales_uom, stock_item.stock_uom),
 				"rate": rate,
 				"warehouse": store.warehouse,
 				"shipstation_order_item_id": item.order_item_id,

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -189,7 +189,7 @@ def create_erpnext_order(
 			{
 				"item_code": item_code,
 				"qty": item.quantity,
-				"uom": frappe.db.get_single_value("Stock Settings", "stock_uom"),
+				"uom": frappe.db.get_value("Item", item_code, "stock_uom"),
 				"conversion_factor": 1,
 				"rate": rate,
 				"warehouse": store.warehouse,

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -185,7 +185,9 @@ def create_erpnext_order(
 		settings = frappe.get_doc("Shipstation Settings", store.parent)
 		stock_item = create_item(item, settings=settings, store=store)
 		uom = stock_item.sales_uom or stock_item.stock_uom
-		conversion_factor = 1 if uom == stock_item.stock_uom else get_uom_conv_factor(uom, stock_item.stock_uom)
+		conversion_factor = (
+			1 if uom == stock_item.stock_uom else get_uom_conv_factor(uom, stock_item.stock_uom)
+		)
 		item_notes = get_item_notes(item)
 		so.append(
 			"items",

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -4,9 +4,9 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Union
 
 import frappe
+from erpnext.stock.doctype.item.item import get_uom_conv_factor
 from frappe.utils import flt, getdate
 from frappe.utils.safe_exec import is_job_queued
-from erpnext.stock.doctype.item.item import get_uom_conv_factor
 from httpx import HTTPError
 
 from shipstation_integration.customer import (

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -189,7 +189,7 @@ def create_erpnext_order(
 			{
 				"item_code": item_code,
 				"qty": item.quantity,
-				"uom": frappe.db.get_value("Item", item_code, "stock_uom"),
+				"uom": frappe.db.get_value("Item", item_code, "sales_uom"),
 				"conversion_factor": 1,
 				"rate": rate,
 				"warehouse": store.warehouse,

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -184,14 +184,16 @@ def create_erpnext_order(
 
 		settings = frappe.get_doc("Shipstation Settings", store.parent)
 		stock_item = create_item(item, settings=settings, store=store)
+		uom = stock_item.sales_uom or stock_item.stock_uom
+		conversion_factor = 1 if uom == stock_item.stock_uom else get_uom_conv_factor(uom, stock_item.stock_uom)
 		item_notes = get_item_notes(item)
 		so.append(
 			"items",
 			{
 				"item_code": stock_item.item_code,
 				"qty": item.quantity,
-				"uom": stock_item.sales_uom,
-				"conversion_factor": get_uom_conv_factor(stock_item.sales_uom, stock_item.stock_uom),
+				"uom": uom,
+				"conversion_factor": conversion_factor,
 				"rate": rate,
 				"warehouse": store.warehouse,
 				"shipstation_order_item_id": item.order_item_id,


### PR DESCRIPTION
I'm not sure what all history might go into this, but it seems not hard to argue that we should be using the sales uom per item on new order items.

If this is not a safe assumption for all, then we could build a few options in the settings.