### PR TITLE
fix: split overweight WWEX handling units so shopFlow can auto-rate

### DIFF
--- a/shipstation_integration/shipstation_integration/freight_providers/wwex_ltl.py
+++ b/shipstation_integration/shipstation_integration/freight_providers/wwex_ltl.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 import time
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -358,6 +359,12 @@ class WwexLTL(BaseLTL):
 
 	DIM_UNIT = {"inches": "IN", "centimeters": "CM", "feet": "FT"}
 
+	# WWEX will not auto-rate a handling unit heavier than this; overweight units
+	# come back as zero offers with the misleading ineligibleReason "There are no
+	# carriers available to/from that combination of zip codes" (confirmed with
+	# WWEX support: split the weight across more units via ``quantity``).
+	MAX_HU_WEIGHT_LB = 5000.0
+
 	@staticmethod
 	def shipengine_pkg_weight_value_to_pounds(pkg_weight: dict) -> float:
 		"""Interpret ``ShipstationLTL`` package weight … value/unit as pounds."""
@@ -387,10 +394,17 @@ class WwexLTL(BaseLTL):
 		units = []
 		for pkg in packages:
 			dims = pkg.get("dimensions", {})
-			w_wwex = self.wwex_shipped_item_weight(pkg["weight"])
 			dim_unit = self.DIM_UNIT.get(dims.get("unit", "inches"), "IN")
+			total_lb = self.shipengine_pkg_weight_value_to_pounds(pkg["weight"])
+			if total_lb <= 0:
+				total_lb = 0.01
+			quantity = max(
+				int(pkg.get("quantity", 1)) or 1,
+				math.ceil(total_lb / self.MAX_HU_WEIGHT_LB),
+			)
+			w_wwex = self.wwex_shipped_item_weight({"value": total_lb / quantity, "unit": "pounds"})
 			items = []
-			for _i in range(int(pkg.get("quantity", 1))):
+			for _i in range(quantity):
 				item: dict = {
 					"commodityClass": str(pkg.get("freight_class", "50")),
 					"commodityDescription": pkg.get("description") or "",
@@ -404,7 +418,7 @@ class WwexLTL(BaseLTL):
 
 			unit = {
 				"packagingType": (pkg.get("code") or "PLT").upper(),
-				"quantity": int(pkg.get("quantity", 1)),
+				"quantity": quantity,
 				"weight": w_wwex,
 				"billedDimension": {
 					"length": {"value": str(dims.get("length", 0)), "unit": dim_unit},
@@ -454,18 +468,19 @@ class WwexLTL(BaseLTL):
 		if total_lb <= 0:
 			total_lb = 0.01
 
+		handling_units = self.build_handling_units(doc, packages)
 		payload: dict = {
 			"productType": "LTL",
 			"shipment": {
 				"shipmentDate": self.wwex_shop_flow_shipment_date(doc),
 				"originAddress": origin,
 				"destinationAddress": dest,
-				"handlingUnitList": self.build_handling_units(doc, packages),
+				"handlingUnitList": handling_units,
 				"totalWeight": {
 					"value": str(round(total_lb, 3)),
 					"unit": "LB",
 				},
-				"totalHandlingUnitCount": len(packages),
+				"totalHandlingUnitCount": sum(int(u.get("quantity", 1)) for u in handling_units),
 				"pickupSpecialInstructions": doc.get("description_of_content") or "",
 				"deliverySpecialInstructions": "",
 			},


### PR DESCRIPTION
WWEX shopFlow returns zero offers when a single handling unit is too heavy for carriers to auto-rate. The response reports this as lane ineligibility ("There are no carriers available to/from that combination of zip codes. Please contact your representative."), which reads like an account or contracts problem. WWEX support confirmed the real cause is per-unit weight (5,500 lb on one pallet in our case) and advised spreading the weight across more handling units via the quantity field.

Changes:

- `build_handling_units` caps per-unit weight at 5,000 lb: it raises `quantity` so no unit exceeds the cap, and sends per-unit weight (package total divided by quantity) on the unit and on each shippedItem. Previously a package with quantity greater than 1 sent the full package weight on every unit and every item.
- `totalHandlingUnitCount` now sums unit quantities instead of counting parcel groups.

Verified live against the production WWEX account on the lane Commerce CA 90040 to Grapevine TX 76051 (1 parcel group, 5,500 lb, class 50):

- Unpatched request: HTTP 200, `shopRS.ineligible = true`, empty offerList.
- Patched request: 2 units at 2,750 lb each, 12 offers returned, cheapest XPO at $907.51 (correlationId `WWEX-ERP-54f86add-fb34-43af-9f4a-3399335770e0`).