### PR TITLE
fix: LTL quote failures on freight class, carrier id and pickup window

### DIFF
--- a/shipstation_integration/ltl.py
+++ b/shipstation_integration/ltl.py
@@ -220,6 +220,18 @@ def validate_ltl_parcel_dimensions_inches(
 	)
 
 
+def format_freight_class(freight_class, default: float = 50) -> str:
+	"""Render an NMFC freight class the way carrier APIs expect it.
+
+	77.5 and 92.5 are the only half classes in the NMFC scale, so ``int()`` turns them into 77
+	and 92, which are not classes at all. Carriers do not reject the request for that: they
+	quietly drop out of the rate response, and the shipment comes back with a fraction of the
+	usual offers at a much higher price. Whole classes still render without a trailing ``.0``.
+	"""
+	value = flt(freight_class) or flt(default)
+	return str(int(value)) if value == int(value) else str(round(value, 1))
+
+
 class ShipstationLTL(BaseLTL):
 	def __init__(self):
 		"""
@@ -393,10 +405,15 @@ class ShipstationLTL(BaseLTL):
 				message=f"Supplier '{supplier_name}' has invalid LTL carrier_id: {carrier_id}",
 			)
 
-		if not settings or not settings.shipstation_api_ltl_carrier_data:
+		# .get() rather than attribute access: shipstation_api_ltl_carrier_data is written by
+		# Shipstation Settings but is not declared in its doctype JSON, so a settings record
+		# that has never synced LTL carriers raises AttributeError here instead of returning
+		# nothing to look up.
+		ltl_carrier_data = settings.get("shipstation_api_ltl_carrier_data") if settings else None
+		if not ltl_carrier_data:
 			return None
 
-		carrier_data = json.loads(settings.shipstation_api_ltl_carrier_data)
+		carrier_data = json.loads(ltl_carrier_data)
 
 		# Look up by name (case-insensitive)
 		supplier_name_lower = supplier_name.lower()
@@ -1228,8 +1245,9 @@ class ShipstationLTL(BaseLTL):
 
 		# Get carrier IDs from stored LTL carrier data
 		carrier_data = []
-		if settings and settings.shipstation_api_ltl_carrier_data:
-			carrier_data = json.loads(settings.shipstation_api_ltl_carrier_data)
+		ltl_carrier_data = settings.get("shipstation_api_ltl_carrier_data") if settings else None
+		if ltl_carrier_data:
+			carrier_data = json.loads(ltl_carrier_data)
 
 		if not carrier_data:
 			co = get_shipment_company_for_ltl(auth)

--- a/shipstation_integration/public/js/shipment_custom.js
+++ b/shipstation_integration/public/js/shipment_custom.js
@@ -237,12 +237,12 @@ async function show_quote_and_spot_quote_fields(frm) {
 					!frm.doc.quote_or_offer_id
 				) {
 					frm.add_custom_button(__('Get LTL Quotes'), () => {
+						const progress = start_ltl_quote_progress()
 						frappe.call({
 							method: 'shipstation_integration.shipstation_integration.overrides.shipment.fetch_ltl_quotes',
 							args: { doc: frm.doc, settings_name: null },
-							freeze: true,
-							freeze_message: __('Fetching LTL quotes…'),
 							callback: function (r) {
+								progress.finish()
 								const quotes = r && r.message
 								if (!quotes || !quotes.length) {
 									frappe.msgprint(__('No LTL quotes returned for this shipment.'))
@@ -250,6 +250,7 @@ async function show_quote_and_spot_quote_fields(frm) {
 								}
 								show_ltl_quote_selection_dialog(frm, quotes)
 							},
+							error: () => progress.abandon(),
 						})
 					})
 				} else {
@@ -257,6 +258,85 @@ async function show_quote_and_spot_quote_fields(frm) {
 				}
 			}
 		})
+}
+
+// Carriers take the better part of a minute to return LTL rates, and the load balancer in front
+// of the site closes the connection at 60 seconds. A plain freeze overlay reports neither, so a
+// slow answer and a dead request look exactly alike from the form. Track the expected duration
+// instead, hold short of full while the request is still open, and let only a real response
+// finish the bar.
+const LTL_QUOTE_EXPECTED_SECONDS = 45
+const LTL_QUOTE_GATEWAY_LIMIT_SECONDS = 60
+
+function ltl_quote_progress_percent(elapsed_seconds) {
+	if (elapsed_seconds <= LTL_QUOTE_EXPECTED_SECONDS) {
+		return (elapsed_seconds / LTL_QUOTE_EXPECTED_SECONDS) * 90
+	}
+	// Overrunning the estimate is normal, so keep creeping rather than stalling at 90, but never
+	// promise a completion we have not actually seen.
+	const overrun = (elapsed_seconds - LTL_QUOTE_EXPECTED_SECONDS) / LTL_QUOTE_EXPECTED_SECONDS
+	return Math.min(97, 90 + overrun * 7)
+}
+
+function ltl_quote_progress_description(elapsed_seconds) {
+	const seconds = Math.round(elapsed_seconds)
+	if (elapsed_seconds >= LTL_QUOTE_GATEWAY_LIMIT_SECONDS) {
+		return __('Still waiting at {0}s, past the {1}s gateway limit. This request may not return.', [
+			seconds,
+			LTL_QUOTE_GATEWAY_LIMIT_SECONDS,
+		])
+	}
+	if (elapsed_seconds >= LTL_QUOTE_EXPECTED_SECONDS) {
+		return __('Still waiting on carriers ({0}s)', [seconds])
+	}
+	return __('Contacting carriers ({0}s)', [seconds])
+}
+
+function start_ltl_quote_progress() {
+	const title = __('Getting LTL Quotes')
+	const started = Date.now()
+	let closed = false
+
+	const render = () => {
+		const elapsed = (Date.now() - started) / 1000
+		frappe.show_progress(title, ltl_quote_progress_percent(elapsed), 100, ltl_quote_progress_description(elapsed))
+	}
+
+	// Same title on every call, so frappe reuses the one dialog instead of stacking them.
+	render()
+	const timer = setInterval(render, 500)
+
+	const stop = () => {
+		if (closed) return false
+		closed = true
+		clearInterval(timer)
+		return true
+	}
+
+	return {
+		finish: () => {
+			if (!stop()) return
+			frappe.show_progress(title, 100, 100, __('Done'))
+			setTimeout(() => frappe.hide_progress(), 500)
+		},
+		abandon: () => {
+			const elapsed = (Date.now() - started) / 1000
+			if (!stop()) return
+			frappe.hide_progress()
+			// A gateway timeout closes the connection without a response, so nothing else is
+			// going to say anything. Quicker failures carry a server message that speaks for itself.
+			if (elapsed >= LTL_QUOTE_GATEWAY_LIMIT_SECONDS) {
+				frappe.msgprint({
+					title: __('LTL quote request timed out'),
+					indicator: 'orange',
+					message: __(
+						'The carriers did not answer within {0} seconds and the connection was closed. Nothing was saved, so this is safe to run again.',
+						[LTL_QUOTE_GATEWAY_LIMIT_SECONDS]
+					),
+				})
+			}
+		},
+	}
 }
 
 function show_ltl_quote_selection_dialog(frm, quotes) {

--- a/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
+++ b/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
@@ -247,9 +247,13 @@ class ShipstationSettings(Document):  # nosemgrep: frappe-modifying-but-not-comi
 
 	def api_ltl_carrier_data(self):
 		"""Return parsed API LTL carrier data."""
-		if not self.shipstation_api_ltl_carrier_data:
+		# .get() to match onload above: shipstation_api_ltl_carrier_data is written by
+		# fetch_ltl_carriers but is declared in no doctype JSON, so reading it as an
+		# attribute raises AttributeError wherever that field was never created by hand.
+		ltl_carrier_data = self.get("shipstation_api_ltl_carrier_data")
+		if not ltl_carrier_data:
 			return []
-		return json.loads(self.shipstation_api_ltl_carrier_data)
+		return json.loads(ltl_carrier_data)
 
 	@frappe.whitelist()
 	def fetch_ltl_carriers(self):

--- a/shipstation_integration/shipstation_integration/freight_providers/banyan_ltl.py
+++ b/shipstation_integration/shipstation_integration/freight_providers/banyan_ltl.py
@@ -56,7 +56,11 @@ from shipstation_integration.base_ltl import (
 	persist_shipment_ltl_fields,
 	require_submitted_shipment_for_ltl,
 )
-from shipstation_integration.ltl import LTL_SUPPORTED_DIMENSION_UOMS, ShipstationLTL
+from shipstation_integration.ltl import (
+	LTL_SUPPORTED_DIMENSION_UOMS,
+	ShipstationLTL,
+	format_freight_class,
+)
 from shipstation_integration.shipstation_integration.doctype.freight_carrier_settings.freight_carrier_settings import (
 	get_freight_carrier_settings,
 )
@@ -333,7 +337,7 @@ class BanyanLTL(BaseLTL):
 			product = {
 				"PackageType": pkg.get("code") or "Pallets",
 				"Description": pkg.get("description") or "",
-				"Class": str(int(pkg.get("freight_class") or 50)),
+				"Class": format_freight_class(pkg.get("freight_class")),
 				"Weight": float(pkg["weight"]["value"]),
 				"WeightUnitOfMeasurement": wt_uom,
 				"Dimensions": {

--- a/shipstation_integration/shipstation_integration/freight_providers/odfl_ltl.py
+++ b/shipstation_integration/shipstation_integration/freight_providers/odfl_ltl.py
@@ -58,7 +58,11 @@ from shipstation_integration.base_ltl import (
 	persist_shipment_ltl_fields,
 	require_submitted_shipment_for_ltl,
 )
-from shipstation_integration.ltl import LTL_SUPPORTED_DIMENSION_UOMS, ShipstationLTL
+from shipstation_integration.ltl import (
+	LTL_SUPPORTED_DIMENSION_UOMS,
+	ShipstationLTL,
+	format_freight_class,
+)
 from shipstation_integration.shipstation_integration.doctype.freight_carrier_settings.freight_carrier_settings import (
 	get_freight_carrier_settings,
 )
@@ -470,7 +474,7 @@ class OdflLTL(BaseLTL):
 		packages = ltl.build_packages_from_sdn(doc)
 		freight_items_xml = "\n".join(
 			FREIGHT_ITEM_TEMPLATE.format(
-				freight_class=int(float(p.get("freight_class", 50))),
+				freight_class=format_freight_class(p.get("freight_class")),
 				weight=self.package_weight_to_pounds(p["weight"]),
 				pieces=int(p.get("quantity", 1)),
 			)
@@ -699,7 +703,7 @@ class OdflLTL(BaseLTL):
 			weight_lb = ShipstationLTL.package_weight_pounds(pkg)
 			line_item: dict[str, Any] = {
 				"weight": weight_lb,
-				"classification": str(pkg.get("freight_class", "50")),
+				"classification": format_freight_class(pkg.get("freight_class")),
 				"description": (pkg.get("description") or doc.get("description_of_content") or "Freight")[:50],
 				"hazardous": bool(doc.get("hazardous_material")),
 				"pieces": max(int(pkg.get("quantity", 1)), 1),

--- a/shipstation_integration/shipstation_integration/freight_providers/traffictech_ltl.py
+++ b/shipstation_integration/shipstation_integration/freight_providers/traffictech_ltl.py
@@ -37,7 +37,11 @@ import httpx
 from frappe import _
 from frappe.utils import flt, getdate
 from shipstation_integration.base_ltl import BaseLTL, require_submitted_shipment_for_ltl
-from shipstation_integration.ltl import LTL_SUPPORTED_DIMENSION_UOMS, ShipstationLTL
+from shipstation_integration.ltl import (
+	LTL_SUPPORTED_DIMENSION_UOMS,
+	ShipstationLTL,
+	format_freight_class,
+)
 from shipstation_integration.api.rates import get_state_code
 from shipstation_integration.shipstation_integration.doctype.freight_carrier_settings.freight_carrier_settings import (
 	get_freight_carrier_settings,
@@ -277,8 +281,7 @@ class TrafficTechLTL(BaseLTL):
 		for pkg in packages:
 			length, width, height = ShipstationLTL.package_dimensions_inches(pkg)
 			weight_lb = ShipstationLTL.package_weight_pounds(pkg) or 1
-			freight_class = pkg.get("freight_class")
-			cls = str(freight_class) if freight_class is not None else "50"
+			cls = format_freight_class(pkg.get("freight_class"))
 			desc = (pkg.get("description") or doc.get("description_of_content") or "Freight")[:200]
 			pkg_type, pkg_desc = self.package_type_for_tt(doc, pkg)
 			item: dict[str, Any] = {

--- a/shipstation_integration/shipstation_integration/freight_providers/wwex_ltl.py
+++ b/shipstation_integration/shipstation_integration/freight_providers/wwex_ltl.py
@@ -64,7 +64,11 @@ from shipstation_integration.base_ltl import (
 	persist_shipment_ltl_fields,
 	require_submitted_shipment_for_ltl,
 )
-from shipstation_integration.ltl import LTL_SUPPORTED_DIMENSION_UOMS, ShipstationLTL
+from shipstation_integration.ltl import (
+	LTL_SUPPORTED_DIMENSION_UOMS,
+	ShipstationLTL,
+	format_freight_class,
+)
 from shipstation_integration.shipstation_integration.doctype.freight_carrier_settings.freight_carrier_settings import (
 	get_freight_carrier_settings,
 )
@@ -392,7 +396,7 @@ class WwexLTL(BaseLTL):
 			items = []
 			for _i in range(int(pkg.get("quantity", 1))):
 				item: dict = {
-					"commodityClass": str(pkg.get("freight_class", "50")),
+					"commodityClass": format_freight_class(pkg.get("freight_class")),
 					"commodityDescription": pkg.get("description") or "",
 					"isHazMat": bool(doc.get("hazardous_material")),
 					"weight": w_wwex,

--- a/shipstation_integration/shipstation_integration/overrides/shipment.py
+++ b/shipstation_integration/shipstation_integration/overrides/shipment.py
@@ -14,6 +14,7 @@ the desk.
 """
 
 import json
+from datetime import datetime, timedelta
 from typing import Any
 
 import frappe
@@ -34,6 +35,11 @@ def ltl_settings_name(settings_name: str | None) -> str | None:
 	return settings.name if settings else None
 
 
+# Carriers dispatch against a window, not an instant. Anything narrower than this is not
+# a window they can send a truck to, so treat it as absent rather than as a request.
+MINIMUM_PICKUP_WINDOW = timedelta(minutes=30)
+
+
 class ShipStationShipment(Shipment):
 	def validate(self):
 		if self.get("freight_type") == "LTL":
@@ -47,16 +53,20 @@ class ShipStationShipment(Shipment):
 		super().validate()
 
 	def normalize_pickup_window(self) -> None:
-		"""Restore the default pickup window when this one has no room in it.
+		"""Restore the default pickup window when this one is too narrow to dispatch against.
 
-		A Shipment built from a Delivery Note can arrive with pickup_from equal to pickup_to,
-		both stamped with the moment it was created. That is a pickup window of zero minutes:
-		carriers either refuse it or quietly substitute a window of their own, so the rate that
-		comes back is not for the pickup shown on the form.
+		A Shipment built from a Delivery Note arrives with pickup_from and pickup_to both
+		stamped with the moment it was created, microseconds apart. Carriers either refuse a
+		window that narrow or quietly substitute one of their own, so the rate that comes back
+		is not for the pickup shown on the form. Direction alone is not the test: the window
+		that prompted this was 25 microseconds wide and still ran forwards.
 		"""
 		start, end = self.get("pickup_from"), self.get("pickup_to")
-		if start and end and get_time(start) < get_time(end):
-			return
+		if start and end:
+			opens = datetime.combine(datetime.min, get_time(start))
+			closes = datetime.combine(datetime.min, get_time(end))
+			if closes - opens >= MINIMUM_PICKUP_WINDOW:
+				return
 		meta = frappe.get_meta("Shipment")
 		self.pickup_from = meta.get_field("pickup_from").default or "09:00:00"
 		self.pickup_to = meta.get_field("pickup_to").default or "17:00:00"

--- a/shipstation_integration/shipstation_integration/overrides/shipment.py
+++ b/shipstation_integration/shipstation_integration/overrides/shipment.py
@@ -19,6 +19,7 @@ from typing import Any
 import frappe
 from erpnext.stock.doctype.shipment.shipment import Shipment
 from frappe import _
+from frappe.utils import get_time
 
 from shipstation_integration.base_ltl import require_submitted_shipment_for_ltl
 from shipstation_integration.ltl import get_ltl_provider
@@ -35,13 +36,30 @@ def ltl_settings_name(settings_name: str | None) -> str | None:
 
 class ShipStationShipment(Shipment):
 	def validate(self):
-		if self.get("freight_type") == "LTL" and not self.get("delivery_contact_name"):
-			frappe.throw(
-				_("Delivery Contact is required for LTL shipments."),
-				title=_("Delivery contact required"),
-			)
+		if self.get("freight_type") == "LTL":
+			if not self.get("delivery_contact_name"):
+				frappe.throw(
+					_("Delivery Contact is required for LTL shipments."),
+					title=_("Delivery contact required"),
+				)
+			self.normalize_pickup_window()
 		# TODO: if freight_type == "LTL" -> call ltl_class method to show missing but required fields
 		super().validate()
+
+	def normalize_pickup_window(self) -> None:
+		"""Restore the default pickup window when this one has no room in it.
+
+		A Shipment built from a Delivery Note can arrive with pickup_from equal to pickup_to,
+		both stamped with the moment it was created. That is a pickup window of zero minutes:
+		carriers either refuse it or quietly substitute a window of their own, so the rate that
+		comes back is not for the pickup shown on the form.
+		"""
+		start, end = self.get("pickup_from"), self.get("pickup_to")
+		if start and end and get_time(start) < get_time(end):
+			return
+		meta = frappe.get_meta("Shipment")
+		self.pickup_from = meta.get_field("pickup_from").default or "09:00:00"
+		self.pickup_to = meta.get_field("pickup_to").default or "17:00:00"
 
 	def before_submit(self):
 		"""
@@ -96,7 +114,16 @@ def get_carrier_id_for_supplier(
 	"""
 	if company is None:
 		company = frappe.defaults.get_user_default("Company")
-	ltl_class = get_ltl_provider()
+	# The form calls this with nothing but the carrier, so hand get_ltl_provider enough of a
+	# Shipment to resolve against. Called bare it always falls back to ShipstationLTL, which
+	# then goes looking for a ShipEngine carrier_id that a Banyan or ODFL supplier was never
+	# going to have.
+	context = frappe._dict(
+		preferred_carrier=supplier_name,
+		pickup_from_type="Company",
+		pickup_company=company,
+	)
+	ltl_class = get_ltl_provider(context)
 	return ltl_class.get_carrier_id_for_supplier(
 		supplier_name, ltl_settings_name(settings_name), company
 	)

--- a/shipstation_integration/tests/test_ltl.py
+++ b/shipstation_integration/tests/test_ltl.py
@@ -463,3 +463,29 @@ def test_ltl_carriers_expose_millimeter_dimension_uom():
 		assert abs(dims["height"] - 60) < 1
 	finally:
 		restore_ltl_shipment(shipment, original)
+
+
+@pytest.mark.order(52)
+def test_microsecond_pickup_window_is_replaced_with_the_default():
+	"""A window can run forwards and still be far too narrow to send a truck to.
+
+	Shipments created from a Delivery Note stamp pickup_from and pickup_to from the same
+	clock read, so they land microseconds apart rather than equal.
+	"""
+	shipment = get_draft_ltl_shipment_for_tests()
+	shipment.pickup_from = "16:01:45.285051"
+	shipment.pickup_to = "16:01:45.285076"
+	shipment.normalize_pickup_window()
+	meta = frappe.get_meta("Shipment")
+	assert shipment.pickup_from == (meta.get_field("pickup_from").default or "09:00:00")
+	assert shipment.pickup_to == (meta.get_field("pickup_to").default or "17:00:00")
+
+
+@pytest.mark.order(53)
+def test_a_real_pickup_window_is_left_alone():
+	shipment = get_draft_ltl_shipment_for_tests()
+	shipment.pickup_from = "10:00:00"
+	shipment.pickup_to = "15:00:00"
+	shipment.normalize_pickup_window()
+	assert shipment.pickup_from == "10:00:00"
+	assert shipment.pickup_to == "15:00:00"

--- a/shipstation_integration/tests/test_ltl.py
+++ b/shipstation_integration/tests/test_ltl.py
@@ -10,6 +10,7 @@ from shipstation_integration.ltl import (
 	ShipstationLTL,
 	centimeter_values_are_millimeter_magnitudes,
 	effective_sdn_dimension_uom,
+	format_freight_class,
 	get_ltl_provider,
 	sdn_dimensions_to_inches,
 )
@@ -144,6 +145,48 @@ def restore_ltl_shipment(shipment, original):
 )
 def test_density_to_freight_class_boundaries(density, expected_class):
 	assert ShipstationLTL().density_to_freight_class(density) == expected_class
+
+
+@pytest.mark.order(50)
+@pytest.mark.parametrize(
+	("value", "expected"),
+	[
+		(77.5, "77.5"),
+		(92.5, "92.5"),
+		("77.5", "77.5"),
+		(70, "70"),
+		(70.0, "70"),
+		(None, "50"),
+		(0, "50"),
+	],
+)
+def test_format_freight_class(value, expected):
+	assert format_freight_class(value) == expected
+
+
+@pytest.mark.order(50)
+def test_banyan_handling_units_keep_half_freight_class(monkeypatch):
+	"""77.5 has to reach Banyan intact.
+
+	Truncating it to 77 does not fail the request: carriers that only answer whole classes drop
+	off the response instead, so the shipment comes back with a handful of offers at roughly
+	double the price of the correct class.
+	"""
+	packages = [
+		{
+			"code": "Pallets",
+			"freight_class": 77.5,
+			"description": "Test freight",
+			"dimensions": {"length": 48, "width": 40, "height": 60, "unit": "inches"},
+			"weight": {"value": 999, "unit": "pounds"},
+			"quantity": 1,
+		}
+	]
+	monkeypatch.setattr(ShipstationLTL, "build_packages_from_sdn", lambda self, doc: packages)
+
+	units = BanyanLTL().build_handling_units(frappe._dict())
+
+	assert units[0]["Products"][0]["Class"] == "77.5"
 
 
 @pytest.mark.order(51)

--- a/shipstation_integration/utils.py
+++ b/shipstation_integration/utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 
 import frappe
 from frappe import _
+from frappe.utils import flt
 from shipengine.errors import ShipEngineError
 
 if TYPE_CHECKING:
@@ -94,9 +95,9 @@ def find_matching_parcel_template(
 
 	# Convert input dimensions to cm
 	conversion_factor = DIMENSION_TO_CM.get(dimension_uom, 1.0)
-	length_cm = float(length) * conversion_factor
-	width_cm = float(width) * conversion_factor
-	height_cm = float(height) * conversion_factor
+	length_cm = flt(length) * conversion_factor
+	width_cm = flt(width) * conversion_factor
+	height_cm = flt(height) * conversion_factor
 
 	# Get all parcel templates
 	templates = frappe.get_all(
@@ -105,11 +106,12 @@ def find_matching_parcel_template(
 	)
 
 	for template in templates:
-		# Check if dimensions match within tolerance
+		# flt() rather than the raw values: a template saved without one of its dimensions
+		# stores NULL, and subtracting that from a float raises rather than simply not matching.
 		if (
-			abs(template.length - length_cm) <= tolerance
-			and abs(template.width - width_cm) <= tolerance
-			and abs(template.height - height_cm) <= tolerance
+			abs(flt(template.length) - length_cm) <= tolerance
+			and abs(flt(template.width) - width_cm) <= tolerance
+			and abs(flt(template.height) - height_cm) <= tolerance
 		):
 			return template.name
 


### PR DESCRIPTION
Draft while we finish testing on uat5. Safe to pull from this branch if a bench needs the fixes before it merges.

Based on `staging` rather than `version-15`, because the direct-API LTL code (`ltl.py`, `freight_providers/`, `overrides/shipment.py`) exists only on `staging`.

## What prompted it

A user ran an LTL rate shop and got 2 offers at $792 on a lane that normally returns 10 at $382. Measured against live Banyan, same lane and day, Columbus OH to CA, 2 pallets 48x40x60:

| class sent | offers | cheapest |
|---|---|---|
| `70` | 10 | Saia $382.46 |
| `77.5` | 10 | Saia $408.83 |
| `77` | 4 | Daylight $820.62 |

`build_packages_from_sdn` correctly derives class 77.5 from density, then `str(int(...))` in `banyan_ltl.py` truncated it to `77`. 77.5 and 92.5 are the only half classes in the NMFC scale, so both get mangled. Carriers do not reject an invalid class, they drop out of the response, so the shipment simply looks like it has fewer options.

The same form also 500s on load. `get_carrier_id_for_supplier` is called from JS with no doc, so `get_ltl_provider()` falls back to `ShipstationLTL` whatever carrier is selected, and then reads `settings.shipstation_api_ltl_carrier_data` as an attribute.

## Changes

- New `format_freight_class()` in `ltl.py`, called by all four providers instead of their own `int()`/`str()`. Besides the truncation, `str()` rendered whole classes as `"100.0"`, which carriers reject as flatly as `"77"`.
- `get_carrier_id_for_supplier` builds a `frappe._dict` carrying enough of a Shipment for `get_ltl_provider` to resolve the real provider.
- `shipstation_api_ltl_carrier_data` read via `.get()` at all sites, matching the pattern `onload` already uses.
- `normalize_pickup_window()` tests the width of the window against a 30 minute minimum. Direction alone is the wrong test: Shipments built from a Delivery Note stamp `pickup_from` and `pickup_to` from the same clock read, so they land microseconds apart and still run forwards.
- `find_matching_parcel_template` uses `flt()` on both sides so a template saved without a dimension does not raise.
- `shipment_custom.js` shows a progress bar rather than a freeze overlay while quotes are fetched, and names the gateway limit past 60s.

## Open question, deliberately not fixed here

None of the LTL fields on Shipstation Settings are declared in `shipstation_settings.json`: not `shipstation_api_ltl_carrier_data`, not `ltl_fetch_freight_carrier_settings`, and nothing in the app creates them. On a real site the column is absent and there is no Custom Field, so `fetch_ltl_carriers()` assigns the carrier list, calls `save()`, silently discards it, and still reports "Successfully fetched N LTL carriers". `tests/setup.py:737` sets the other one.

The `.get()` guards here stop the AttributeError, but the lookup path stays permanently empty. Declaring the fields is the real fix. I left it out because the layout is your call and it needs a migrate. Happy to add it if you say what shape you want.

## Testing

Applied by hand to a UAT bench and verified there: 32 checks pass, `get_carrier_id_for_supplier` no longer raises for any of the 11 transporters, and Banyan and ODFL resolve to their own providers instead of falling back. Two regression tests added for the pickup window. Not yet run through a full pytest bench, which is what the draft status is for.
